### PR TITLE
test: integration tests for plugin and composable

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.5.2",
+    "@vitejs/plugin-vue": "^6.0.5",
     "@vue/test-utils": "^2.4.6",
     "happy-dom": "^20.8.9",
     "husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@types/node':
         specifier: ^25.5.2
         version: 25.5.2
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.5
+        version: 6.0.5(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))
       '@vue/test-utils':
         specifier: ^2.4.6
         version: 2.4.6
@@ -429,6 +432,9 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.12':
     resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
 
+  '@rolldown/pluginutils@1.0.0-rc.2':
+    resolution: {integrity: sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==}
+
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
@@ -494,6 +500,13 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@vitejs/plugin-vue@6.0.5':
+    resolution: {integrity: sha512-bL3AxKuQySfk1iGcBsQnoRVexTPJq0Z/ixFVM8OhVJAP6ZXXXLtM7NFKWhLl30Kg7uTBqIaPXbh+nuQCuBDedg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vue: ^3.2.25
 
   '@vitest/expect@4.1.2':
     resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
@@ -1632,6 +1645,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.12': {}
 
+  '@rolldown/pluginutils@1.0.0-rc.2': {}
+
   '@rollup/pluginutils@5.3.0':
     dependencies:
       '@types/estree': 1.0.8
@@ -1704,6 +1719,12 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 25.5.2
+
+  '@vitejs/plugin-vue@6.0.5(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.2
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(yaml@2.8.3)
+      vue: 3.5.32(typescript@6.0.2)
 
   '@vitest/expect@4.1.2':
     dependencies:

--- a/src/__tests__/fixtures/HeavyComponent.vue
+++ b/src/__tests__/fixtures/HeavyComponent.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>
+    <span v-for="i in count" :key="i">{{ i }}</span>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ count?: number }>();
+</script>

--- a/src/__tests__/fixtures/SimpleComponent.vue
+++ b/src/__tests__/fixtures/SimpleComponent.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>{{ message }}</div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ message?: string }>();
+</script>

--- a/src/__tests__/fixtures/UpdatingComponent.vue
+++ b/src/__tests__/fixtures/UpdatingComponent.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>{{ value }}</div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const value = ref(0);
+
+function increment() {
+  value.value++;
+}
+
+defineExpose({ increment });
+</script>

--- a/src/__tests__/plugin.test.ts
+++ b/src/__tests__/plugin.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { defineComponent, nextTick } from 'vue';
+import { VueRenderDiagnostics } from '../plugin/install.ts';
+import { useRenderDiagnostics } from '../composables/useRenderDiagnostics.ts';
+import { clearFilterCache } from '../plugin/lifecycle-tracker.ts';
+import type { VRTComponentLog } from '../types.ts';
+import SimpleComponent from './fixtures/SimpleComponent.vue';
+import UpdatingComponent from './fixtures/UpdatingComponent.vue';
+
+function mountWithPlugin<T extends Record<string, unknown>>(
+  component: Parameters<typeof mount>[0],
+  options?: { pluginOptions?: Parameters<typeof VueRenderDiagnostics.install>[1]; props?: T },
+) {
+  return mount(component, {
+    props: options?.props,
+    global: {
+      plugins: [[VueRenderDiagnostics, options?.pluginOptions ?? {}]],
+    },
+  });
+}
+
+function logsFor(logs: VRTComponentLog[], name: string): VRTComponentLog[] {
+  return logs.filter((l) => l.component === name);
+}
+
+describe('VueRenderDiagnostics plugin', () => {
+  beforeEach(() => {
+    clearFilterCache();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('emits log on component unmount', () => {
+    const logs: VRTComponentLog[] = [];
+    const wrapper = mountWithPlugin(SimpleComponent, {
+      pluginOptions: { onLog: (log) => logs.push(log) },
+      props: { message: 'hello' },
+    });
+
+    wrapper.unmount();
+
+    const componentLogs = logsFor(logs, 'SimpleComponent');
+    expect(componentLogs).toHaveLength(1);
+    expect(componentLogs[0].type).toBe('vrt:component');
+    expect(componentLogs[0].metrics.mountTimeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('tracks update metrics', async () => {
+    const logs: VRTComponentLog[] = [];
+    const wrapper = mountWithPlugin(UpdatingComponent, {
+      pluginOptions: { onLog: (log) => logs.push(log) },
+    });
+
+    wrapper.vm.increment();
+    await nextTick();
+
+    wrapper.vm.increment();
+    await nextTick();
+
+    wrapper.unmount();
+
+    const componentLogs = logsFor(logs, 'UpdatingComponent');
+    expect(componentLogs).toHaveLength(1);
+    expect(componentLogs[0].metrics.updateCount).toBe(2);
+    expect(componentLogs[0].signals.dataUpdateDetected).toBe(true);
+  });
+
+  it('does not track when enabled is false', () => {
+    const logs: VRTComponentLog[] = [];
+    const wrapper = mountWithPlugin(SimpleComponent, {
+      pluginOptions: { enabled: false, onLog: (log) => logs.push(log) },
+    });
+
+    wrapper.unmount();
+    expect(logs).toHaveLength(0);
+  });
+
+  it('respects include filter', () => {
+    const logs: VRTComponentLog[] = [];
+    const wrapper = mountWithPlugin(SimpleComponent, {
+      pluginOptions: {
+        include: ['NonExistentComponent'],
+        onLog: (log) => logs.push(log),
+      },
+    });
+
+    wrapper.unmount();
+    const componentLogs = logsFor(logs, 'SimpleComponent');
+    expect(componentLogs).toHaveLength(0);
+  });
+
+  it('respects exclude filter', () => {
+    const logs: VRTComponentLog[] = [];
+    const wrapper = mountWithPlugin(SimpleComponent, {
+      pluginOptions: {
+        exclude: ['SimpleComponent'],
+        onLog: (log) => logs.push(log),
+      },
+    });
+
+    wrapper.unmount();
+    const componentLogs = logsFor(logs, 'SimpleComponent');
+    expect(componentLogs).toHaveLength(0);
+  });
+
+  it('logs to console by default', () => {
+    const consoleSpy = vi.spyOn(console, 'log');
+    const wrapper = mountWithPlugin(SimpleComponent);
+
+    wrapper.unmount();
+
+    expect(consoleSpy).toHaveBeenCalledWith('[VRT]', expect.any(String));
+  });
+
+  it('does not log to console when logToConsole is false', () => {
+    const consoleSpy = vi.spyOn(console, 'log');
+    const wrapper = mountWithPlugin(SimpleComponent, {
+      pluginOptions: { logToConsole: false },
+    });
+
+    wrapper.unmount();
+    expect(consoleSpy).not.toHaveBeenCalledWith('[VRT]', expect.any(String));
+  });
+});
+
+describe('useRenderDiagnostics composable', () => {
+  beforeEach(() => {
+    clearFilterCache();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns null metrics without plugin installed', () => {
+    const TestComp = defineComponent({
+      setup() {
+        const { metrics, issues } = useRenderDiagnostics();
+        return { metrics, issues };
+      },
+      template: '<div />',
+    });
+
+    const wrapper = mount(TestComp);
+    expect(wrapper.vm.metrics).toBeNull();
+    expect(wrapper.vm.issues).toEqual([]);
+    wrapper.unmount();
+  });
+
+  it('provides metrics when plugin is installed', async () => {
+    const TestComp = defineComponent({
+      name: 'ComposableTest',
+      setup() {
+        const { metrics, issues, flush } = useRenderDiagnostics();
+        return { metrics, issues, flush };
+      },
+      template: '<div />',
+    });
+
+    const wrapper = mount(TestComp, {
+      global: {
+        plugins: [[VueRenderDiagnostics, { logToConsole: false }]],
+      },
+    });
+
+    wrapper.unmount();
+    await flushPromises();
+
+    expect(wrapper.vm.metrics).not.toBeNull();
+    expect(wrapper.vm.metrics!.mountTimeMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,5 +22,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/__tests__"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import vue from '@vitejs/plugin-vue';
 
 export default defineConfig({
+  plugins: [vue()],
   test: {
     environment: 'happy-dom',
     include: ['src/**/*.test.ts'],


### PR DESCRIPTION
## Summary
- Add fixture components: SimpleComponent, HeavyComponent, UpdatingComponent
- Integration tests covering: mount/unmount logging, update tracking, enabled/include/exclude filtering, console output control, useRenderDiagnostics composable
- Add `@vitejs/plugin-vue` for .vue file support in Vitest
- Exclude test files from `tsc -b` (Vitest handles them independently)

Closes #7

## Test plan
- [x] `pnpm test` — 36 tests pass (9 new integration tests)
- [x] `pnpm build` succeeds
- [x] `pnpm typecheck` passes