### PR TITLE
feat: periodic update log emission

### DIFF
--- a/playground/main.ts
+++ b/playground/main.ts
@@ -4,6 +4,7 @@ import App from './App.vue';
 
 const app = createApp(App);
 app.use(VueRenderDiagnostics, {
+  updateLogInterval: 5,
   onLog: (log) => {
     console.table(log.metrics);
     if (log.issues.length > 0) {

--- a/src/__tests__/plugin.test.ts
+++ b/src/__tests__/plugin.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
-import { defineComponent } from 'vue';
+import { defineComponent, ref, nextTick } from 'vue';
 import { VueRenderDiagnostics } from '../plugin/install.ts';
 import { useRenderDiagnostics } from '../composables/useRenderDiagnostics.ts';
 import { clearFilterCache } from '../plugin/lifecycle-tracker.ts';
@@ -125,6 +125,82 @@ describe('VueRenderDiagnostics plugin', () => {
     wrapper.unmount();
 
     expect(logs).toHaveLength(mountLogs);
+  });
+
+  it('emits update log at configured interval', async () => {
+    const logs: VRTComponentLog[] = [];
+
+    const Counter = defineComponent({
+      name: 'Counter',
+      setup() {
+        const count = ref(0);
+        return { count };
+      },
+      template: '<div>{{ count }}</div>',
+    });
+
+    const wrapper = mount(Counter, {
+      global: {
+        plugins: [
+          [
+            VueRenderDiagnostics,
+            { updateLogInterval: 3, onLog: (log: VRTComponentLog) => logs.push(log) },
+          ],
+        ],
+      },
+    });
+
+    await flushRaf();
+    const afterMount = logsFor(logs, 'Counter').length;
+
+    // Trigger 3 updates
+    for (let i = 0; i < 3; i++) {
+      wrapper.vm.count++;
+      await nextTick();
+    }
+
+    expect(logsFor(logs, 'Counter').length).toBe(afterMount + 1);
+
+    // Trigger 3 more updates
+    for (let i = 0; i < 3; i++) {
+      wrapper.vm.count++;
+      await nextTick();
+    }
+
+    expect(logsFor(logs, 'Counter').length).toBe(afterMount + 2);
+
+    wrapper.unmount();
+  });
+
+  it('does not emit update logs when updateLogInterval is not set', async () => {
+    const logs: VRTComponentLog[] = [];
+
+    const Counter = defineComponent({
+      name: 'Counter2',
+      setup() {
+        const count = ref(0);
+        return { count };
+      },
+      template: '<div>{{ count }}</div>',
+    });
+
+    const wrapper = mount(Counter, {
+      global: {
+        plugins: [[VueRenderDiagnostics, { onLog: (log: VRTComponentLog) => logs.push(log) }]],
+      },
+    });
+
+    await flushRaf();
+    const afterMount = logsFor(logs, 'Counter2').length;
+
+    for (let i = 0; i < 10; i++) {
+      wrapper.vm.count++;
+      await nextTick();
+    }
+
+    expect(logsFor(logs, 'Counter2').length).toBe(afterMount);
+
+    wrapper.unmount();
   });
 });
 

--- a/src/core/collector.ts
+++ b/src/core/collector.ts
@@ -71,6 +71,10 @@ export class Collector {
     tracker.hasAsyncInSetup = true;
   }
 
+  getUpdateCount(uid: number): number {
+    return this.trackers.get(uid)?.updates.length ?? 0;
+  }
+
   peek(uid: number): VRTComponentLog | null {
     const tracker = this.trackers.get(uid);
     if (!tracker) return null;

--- a/src/plugin/lifecycle-tracker.ts
+++ b/src/plugin/lifecycle-tracker.ts
@@ -82,6 +82,13 @@ export function createLifecycleTracker(
       const uid = this.$.uid;
       collector.trackUpdateEnd(uid);
       collector.trackNodeCount(uid, countNodes(this.$el));
+      if (options.updateLogInterval && options.updateLogInterval > 0) {
+        const count = collector.getUpdateCount(uid);
+        if (count > 0 && count % options.updateLogInterval === 0) {
+          const log = collector.peek(uid);
+          if (log) emitLog(log, options);
+        }
+      }
     },
     unmounted(this: VueInstance) {
       const name = getComponentName(this);

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,5 +51,6 @@ export interface VRTPluginOptions {
   exclude?: string[] | RegExp;
   thresholds?: Partial<VRTThresholds>;
   logToConsole?: boolean;
+  updateLogInterval?: number;
   onLog?: (log: VRTComponentLog) => void;
 }


### PR DESCRIPTION
## Summary
- Add `updateLogInterval` plugin option — emits a `[VRT]` snapshot log every N updates
- Add `Collector.getUpdateCount()` to check current update count per component
- Playground configured with `updateLogInterval: 5` for demo

Closes #19

## Test plan
- [x] `pnpm test` — 41 tests pass (2 new: interval emission + no emission without option)
- [x] `pnpm build` succeeds
- [x] Playground: click Count 5 times → `[VRT]` log appears in console