### PR TITLE
docs: update documentation to reflect current architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,19 +9,21 @@ This file provides context for AI coding agents (Cursor, Copilot, Windsurf, etc.
 ```
 src/
   core/            Performance timer, issue detector, logger, metrics collector
-  hooks/           Vue mixin and Composition API composable
+  composables/     useRenderDiagnostics opt-in marker
+  plugin/          Vue plugin install function and lifecycle tracker mixin
   utils/           DOM utilities
-  plugin.ts        Vue plugin install function
   types.ts         All TypeScript type definitions
   constants.ts     Thresholds, prefix, defaults
   index.ts         Public API exports
+  __tests__/       Integration tests and Vue component fixtures
+playground/        Dev app for manual testing (pnpm playground)
 ```
 
 ## Code Style
 
 - ESM modules, `import type` for type-only imports (`verbatimModuleSyntax`)
 - No barrel exports — import directly from source modules
-- File names use kebab-case (e.g. `use-render-diagnostics.ts`)
+- SFC order: `<script setup>` then `<template>`
 - Tests follow `*.test.ts` naming, colocated in `src/`
 - Format with Oxfmt (`singleQuote`, trailing commas, `printWidth: 100`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ vue-render-diagnostics is a Vue 3 plugin that captures component rendering metri
 - `pnpm fmt:check` — Check formatting without writing
 - `pnpm test` — Run tests with Vitest
 - `pnpm test:watch` — Run tests in watch mode
+- `pnpm playground` — Dev server for the playground app
 
 Package manager is **pnpm** (not npm/yarn). Runtime: Node.js 24, pnpm 10 (managed via `.mise.toml`).
 
@@ -36,19 +37,22 @@ Vue plugin library distributed as ESM/UMD with TypeScript declarations.
 
 Pure-function modules with zero Vue API dependency — fully testable:
 
-- `timer.ts` — `performance.now()` wrapper and paint time measurement
+- `timer.ts` — `performance.now()` wrapper and double-rAF paint time measurement
 - `detector.ts` — Issue detection from metrics against thresholds
 - `logger.ts` — `[VRT]` prefixed structured JSON console output
-- `collector.ts` — Per-component metrics accumulation across lifecycle hooks
+- `collector.ts` — Per-component metrics accumulation across lifecycle hooks, with `peek()` for snapshots and `flush()` for cleanup
 
-### Vue Integration (`src/hooks/`)
+### Vue Integration
 
-- `mixin.ts` — Global mixin for automatic component tracking
-- `useRenderDiagnostics.ts` — Composition API composable for per-component opt-in
+- `src/plugin/install.ts` — Vue plugin `install()` function: option merging, collector creation, provide/inject, mixin registration
+- `src/plugin/lifecycle-tracker.ts` — Global mixin hooking into beforeMount/mounted/beforeUpdate/updated/unmounted with include/exclude filtering
+- `src/composables/useRenderDiagnostics.ts` — Opt-in marker: call in `setup()` to track a component regardless of include/exclude filters
 
-### Plugin (`src/plugin.ts`)
+### Log Emission Timing
 
-Vue plugin `install()` function — option merging, collector creation, provide/inject, mixin registration. Disabled in production by default.
+- **Mount completion** — `[VRT]` log emitted after paint measurement (double-rAF) for every tracked component
+- **Periodic updates** — When `updateLogInterval` is set, emits a snapshot every N updates
+- **Unmount** — Cleans up tracker (no log emission)
 
 ### Log Format
 
@@ -57,9 +61,16 @@ Vue plugin `install()` function — option merging, collector creation, provide/
   "type": "vrt:component",
   "component": "ComponentName",
   "timestamp": 1710000000000,
-  "metrics": { "mountTimeMs": 120, "paintTimeMs": 140, ... },
-  "signals": { "hasAsyncInSetup": true, ... },
-  "issues": [{ "id": "slow-mount", "severity": "warn", ... }]
+  "metrics": {
+    "mountTimeMs": 120,
+    "paintTimeMs": 140,
+    "updateCount": 5,
+    "avgUpdateMs": 18,
+    "maxUpdateMs": 40,
+    "nodeCount": 1200
+  },
+  "signals": { "hasAsyncInSetup": true, "dataUpdateDetected": true },
+  "issues": [{ "id": "slow-mount", "severity": "warn", "metric": "mountTimeMs", "value": 120 }]
 }
 ```
 
@@ -68,6 +79,7 @@ Vue plugin `install()` function — option merging, collector creation, provide/
 - ESM modules (`"type": "module"`)
 - Use `import type` for type-only imports (`verbatimModuleSyntax` is enabled)
 - No barrel exports — import directly from the source module
+- SFC order: `<script setup>` then `<template>`
 - Format with Oxfmt before committing
 - Tests colocated in `src/` as `*.test.ts`
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ app.use(VueRenderDiagnostics);
 app.mount('#app');
 ```
 
-Open your browser console — you'll see `[VRT]` prefixed JSON logs when components unmount.
+Open your browser console — you'll see `[VRT]` prefixed JSON logs when components mount.
 
 ### Plugin Options
 
@@ -30,6 +30,7 @@ app.use(VueRenderDiagnostics, {
   include: ['UserList', 'Header'], // track only these components (string[] or RegExp)
   exclude: /^Internal/, // skip matching components (string[] or RegExp)
   logToConsole: true, // default: true
+  updateLogInterval: 10, // emit snapshot every 10 updates (default: disabled)
   thresholds: {
     mountTimeMs: 50, // default: 50
     updateTimeMs: 16, // default: 16 (one frame at 60fps)
@@ -38,19 +39,27 @@ app.use(VueRenderDiagnostics, {
     updateCount: 20, // default: 20
   },
   onLog: (log) => {
-    // programmatic consumer
     sendToAnalytics(log);
   },
 });
 ```
 
-### Composition API
+### Opt-in Tracking
+
+Use the composable to track a specific component regardless of include/exclude filters:
 
 ```ts
 import { useRenderDiagnostics } from 'vue-render-diagnostics';
 
-const { metrics, issues, flush } = useRenderDiagnostics();
+// In setup()
+useRenderDiagnostics();
 ```
+
+## Log Emission Timing
+
+- **Mount completion** — emitted after paint measurement for every tracked component
+- **Periodic updates** — when `updateLogInterval` is set, emits a snapshot every N updates
+- **Unmount** — cleans up internal tracker (no log emission)
 
 ## Log Format
 


### PR DESCRIPTION
## Summary
- Fix directory structure references: `hooks/` → `composables/` + `plugin/`
- Fix composable API description: reactive refs → opt-in marker
- Fix log emission timing: unmount → mount completion + periodic updates
- Add `updateLogInterval` option to all docs
- Add `pnpm playground` command to CLAUDE.md
- Add SFC order convention (script then template)

## Test plan
- [x] `pnpm test` — 41 tests pass (no changes to code)
- [x] `pnpm build` succeeds