### PR TITLE
fix: replace unbounded updates array with incremental aggregates

### DIFF
--- a/src/core/collector.test.ts
+++ b/src/core/collector.test.ts
@@ -188,6 +188,80 @@ describe('Collector', () => {
     expect(second!.metrics.maxUpdateMs).toBe(20);
   });
 
+  it('handles 200k updates without error or excessive memory', () => {
+    const collector = new Collector();
+
+    collector.trackMountStart('StressComp', 1);
+    collector.trackMountEnd(1);
+
+    for (let i = 0; i < 200_000; i++) {
+      now = i * 2;
+      collector.trackUpdateStart(1);
+      now = i * 2 + 1;
+      collector.trackUpdateEnd(1);
+    }
+
+    const log = collector.flush(1);
+    expect(log!.metrics.updateCount).toBe(200_000);
+    expect(log!.metrics.avgUpdateMs).toBe(1);
+    expect(log!.metrics.maxUpdateMs).toBe(1);
+  });
+
+  it('ignores trackUpdateEnd without prior trackUpdateStart', () => {
+    const collector = new Collector();
+
+    collector.trackMountStart('TestComp', 1);
+    collector.trackMountEnd(1);
+
+    // Call trackUpdateEnd without trackUpdateStart
+    collector.trackUpdateEnd(1);
+
+    const log = collector.flush(1);
+    expect(log!.metrics.updateCount).toBe(0);
+    expect(log!.metrics.avgUpdateMs).toBe(0);
+    expect(log!.metrics.maxUpdateMs).toBe(0);
+  });
+
+  it('discards negative elapsed time from clock skew', () => {
+    const collector = new Collector();
+
+    collector.trackMountStart('TestComp', 1);
+    collector.trackMountEnd(1);
+
+    now = 100;
+    collector.trackUpdateStart(1);
+    now = 50; // clock went backwards
+    collector.trackUpdateEnd(1);
+
+    // second trackUpdateEnd without new trackUpdateStart must also be discarded
+    now = 200;
+    collector.trackUpdateEnd(1);
+
+    const log = collector.flush(1);
+    expect(log!.metrics.updateCount).toBe(0);
+    expect(log!.metrics.avgUpdateMs).toBe(0);
+  });
+
+  it('handles sub-millisecond update durations without drift', () => {
+    const collector = new Collector();
+
+    collector.trackMountStart('TestComp', 1);
+    collector.trackMountEnd(1);
+
+    const count = 10_000;
+    for (let i = 0; i < count; i++) {
+      now = i * 0.1;
+      collector.trackUpdateStart(1);
+      now = i * 0.1 + 0.1;
+      collector.trackUpdateEnd(1);
+    }
+
+    const log = collector.flush(1);
+    expect(log!.metrics.updateCount).toBe(count);
+    expect(log!.metrics.avgUpdateMs).toBeCloseTo(0.1, 5);
+    expect(log!.metrics.maxUpdateMs).toBeCloseTo(0.1, 5);
+  });
+
   it('ignores operations on unknown uid', () => {
     const collector = new Collector();
 

--- a/src/core/collector.ts
+++ b/src/core/collector.ts
@@ -7,7 +7,9 @@ interface ComponentTracker {
   mountStart: number | null;
   mountTimeMs: number | null;
   paintTimeMs: number | null;
-  updates: number[];
+  updateCount: number;
+  totalUpdateMs: number;
+  maxUpdateMs: number;
   nodeCount: number;
   hasAsyncInSetup: boolean;
   updateStart: number | null;
@@ -27,7 +29,9 @@ export class Collector {
       mountStart: performance.now(),
       mountTimeMs: null,
       paintTimeMs: null,
-      updates: [],
+      updateCount: 0,
+      totalUpdateMs: 0,
+      maxUpdateMs: 0,
       nodeCount: 0,
       hasAsyncInSetup: false,
       updateStart: null,
@@ -55,8 +59,12 @@ export class Collector {
   trackUpdateEnd(uid: number): void {
     const tracker = this.trackers.get(uid);
     if (!tracker || tracker.updateStart === null) return;
-    tracker.updates.push(performance.now() - tracker.updateStart);
+    const duration = performance.now() - tracker.updateStart;
     tracker.updateStart = null;
+    if (duration < 0) return;
+    tracker.updateCount++;
+    tracker.totalUpdateMs += duration;
+    if (duration > tracker.maxUpdateMs) tracker.maxUpdateMs = duration;
   }
 
   trackNodeCount(uid: number, count: number): void {
@@ -72,7 +80,7 @@ export class Collector {
   }
 
   getUpdateCount(uid: number): number {
-    return this.trackers.get(uid)?.updates.length ?? 0;
+    return this.trackers.get(uid)?.updateCount ?? 0;
   }
 
   peek(uid: number): VRTComponentLog | null {
@@ -89,21 +97,18 @@ export class Collector {
   }
 
   private buildLog(tracker: ComponentTracker): VRTComponentLog {
-    const updateCount = tracker.updates.length;
-    const totalUpdateMs = tracker.updates.reduce((sum, d) => sum + d, 0);
-
     const metrics: VRTMetrics = {
       mountTimeMs: tracker.mountTimeMs ?? 0,
       paintTimeMs: tracker.paintTimeMs ?? 0,
-      updateCount,
-      avgUpdateMs: updateCount > 0 ? totalUpdateMs / updateCount : 0,
-      maxUpdateMs: updateCount > 0 ? Math.max(...tracker.updates) : 0,
+      updateCount: tracker.updateCount,
+      avgUpdateMs: tracker.updateCount > 0 ? tracker.totalUpdateMs / tracker.updateCount : 0,
+      maxUpdateMs: tracker.maxUpdateMs,
       nodeCount: tracker.nodeCount,
     };
 
     const signals: VRTSignals = {
       hasAsyncInSetup: tracker.hasAsyncInSetup,
-      dataUpdateDetected: updateCount > 0,
+      dataUpdateDetected: tracker.updateCount > 0,
     };
 
     return {


### PR DESCRIPTION
## Summary

- Replace `ComponentTracker.updates: number[]` with three O(1) scalar fields (`updateCount`, `totalUpdateMs`, `maxUpdateMs`) tracked incrementally in `trackUpdateEnd()`
- Eliminate unbounded memory growth (~216K entries/hour at 60fps per component) and `Math.max(...updates)` stack overflow past ~100K entries
- Add negative duration guard with `updateStart` null-clear for clock-skew safety

Closes #39, closes #23

## Test plan

- [x] All 45 existing tests pass (no public API changes)
- [x] 200K update stress test — no `RangeError`, correct metrics
- [x] Clock skew test — negative elapsed time discarded, stale `updateStart` cleared
- [x] Orphaned `trackUpdateEnd` (no prior `trackUpdateStart`) — silently ignored
- [x] Sub-millisecond precision test (10K updates at 0.1ms, `toBeCloseTo`)
- [x] `pnpm build`, `pnpm lint`, `pnpm fmt:check` all clean