### PR TITLE
refactor: delegate collector timing to timer module

### DIFF
--- a/src/core/collector.ts
+++ b/src/core/collector.ts
@@ -63,7 +63,7 @@ export class Collector {
 
   trackUpdateEnd(uid: number): void {
     const tracker = this.trackers.get(uid);
-    if (!tracker || tracker.updateTimer === null) return;
+    if (!tracker?.updateTimer) return;
     const duration = tracker.updateTimer.stop();
     tracker.updateTimer = null;
     if (duration < 0) return;


### PR DESCRIPTION
## Summary

- Replace 4 direct `performance.now()` calls in `collector.ts` with `startTimer()`/`TimerHandle` from `timer.ts`
- Centralize all timing logic so SSR guards (#24) only need to be added in `timer.ts`
- Add negative-duration guard to `trackMountEnd` for consistency with `trackUpdateEnd`
- Unify null-check style to optional chaining (`!tracker?.mountTimer`)

Closes #42

## Test plan

- [x] All 45 existing tests pass (no test changes needed — `startTimer()` uses `performance.now()` internally)
- [x] Mount and update timing values remain accurate
- [x] Negative-duration guard on both mount and update paths
- [x] `pnpm build`, `pnpm lint`, `pnpm fmt:check` all clean