### PR TITLE
fix: replace module-level singletons with per-app VRTContext

### DIFF
--- a/src/__tests__/plugin.test.ts
+++ b/src/__tests__/plugin.test.ts
@@ -3,7 +3,6 @@ import { mount } from '@vue/test-utils';
 import { defineComponent, ref, nextTick } from 'vue';
 import { VueRenderDiagnostics } from '../plugin/install.ts';
 import { useRenderDiagnostics } from '../composables/useRenderDiagnostics.ts';
-import { clearFilterCache } from '../plugin/lifecycle-tracker.ts';
 import type { VRTComponentLog } from '../types.ts';
 import SimpleComponent from './fixtures/SimpleComponent.vue';
 
@@ -30,7 +29,6 @@ async function flushRaf(): Promise<void> {
 
 describe('VueRenderDiagnostics plugin', () => {
   beforeEach(() => {
-    clearFilterCache();
     vi.useFakeTimers();
     vi.spyOn(console, 'log').mockImplementation(() => {});
   });
@@ -202,11 +200,36 @@ describe('VueRenderDiagnostics plugin', () => {
 
     wrapper.unmount();
   });
+
+  it('isolates filter state between multiple app instances', async () => {
+    const logsA: VRTComponentLog[] = [];
+    const logsB: VRTComponentLog[] = [];
+
+    // App A includes only SimpleComponent
+    mountWithPlugin(SimpleComponent, {
+      pluginOptions: {
+        include: ['SimpleComponent'],
+        onLog: (log) => logsA.push(log),
+      },
+    });
+
+    // App B excludes SimpleComponent
+    mountWithPlugin(SimpleComponent, {
+      pluginOptions: {
+        exclude: ['SimpleComponent'],
+        onLog: (log) => logsB.push(log),
+      },
+    });
+
+    await flushRaf();
+
+    expect(logsFor(logsA, 'SimpleComponent')).toHaveLength(1);
+    expect(logsFor(logsB, 'SimpleComponent')).toHaveLength(0);
+  });
 });
 
 describe('useRenderDiagnostics composable', () => {
   beforeEach(() => {
-    clearFilterCache();
     vi.useFakeTimers();
     vi.spyOn(console, 'log').mockImplementation(() => {});
   });

--- a/src/composables/useRenderDiagnostics.ts
+++ b/src/composables/useRenderDiagnostics.ts
@@ -1,5 +1,5 @@
-import { getCurrentInstance } from 'vue';
-import { markTracked } from '../plugin/lifecycle-tracker.ts';
+import { getCurrentInstance, inject } from 'vue';
+import { VRT_CONTEXT_KEY } from '../constants.ts';
 
 /**
  * Opt-in a component for VRT tracking.
@@ -10,8 +10,12 @@ export function useRenderDiagnostics(): void {
   const instance = getCurrentInstance();
   if (!instance) return;
 
-  const name = instance.type.__name || instance.type.name;
+  const context = inject(VRT_CONTEXT_KEY);
+  if (!context) return;
+
+  const name = instance.type.name || instance.type.__name;
   if (name) {
-    markTracked(name);
+    context.explicitlyTracked.add(name);
+    context.filterCache.delete(name);
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,12 @@
 import type { InjectionKey } from 'vue';
 import type { VRTThresholds } from './types.ts';
 import type { Collector } from './core/collector.ts';
+import type { VRTContext } from './plugin/context.ts';
 
 export const VRT_PREFIX = '[VRT]';
 
 export const VRT_COLLECTOR_KEY: InjectionKey<Collector> = Symbol('vrt-collector');
+export const VRT_CONTEXT_KEY: InjectionKey<VRTContext> = Symbol('vrt-context');
 
 export const DEFAULT_THRESHOLDS: VRTThresholds = {
   mountTimeMs: 50,

--- a/src/plugin/context.ts
+++ b/src/plugin/context.ts
@@ -1,0 +1,13 @@
+import type { Collector } from '../core/collector.ts';
+import type { VRTPluginOptions } from '../types.ts';
+
+export interface VRTContext {
+  readonly collector: Collector;
+  readonly options: VRTPluginOptions;
+  readonly filterCache: Map<string, boolean>;
+  readonly explicitlyTracked: Set<string>;
+}
+
+export function createVRTContext(collector: Collector, options: VRTPluginOptions): VRTContext {
+  return { collector, options, filterCache: new Map(), explicitlyTracked: new Set() };
+}

--- a/src/plugin/install.ts
+++ b/src/plugin/install.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from 'vue';
 import type { VRTPluginOptions } from '../types.ts';
-import { VRT_COLLECTOR_KEY } from '../constants.ts';
+import { VRT_COLLECTOR_KEY, VRT_CONTEXT_KEY } from '../constants.ts';
 import { Collector } from '../core/collector.ts';
+import { createVRTContext } from './context.ts';
 import { createLifecycleTracker } from './lifecycle-tracker.ts';
 
 export const VueRenderDiagnostics: Plugin<[VRTPluginOptions?]> = {
@@ -9,7 +10,9 @@ export const VueRenderDiagnostics: Plugin<[VRTPluginOptions?]> = {
     if (options.enabled === false) return;
 
     const collector = new Collector(options.thresholds);
+    const context = createVRTContext(collector, options);
     app.provide(VRT_COLLECTOR_KEY, collector);
-    app.mixin(createLifecycleTracker(collector, options));
+    app.provide(VRT_CONTEXT_KEY, context);
+    app.mixin(createLifecycleTracker(context));
   },
 };

--- a/src/plugin/lifecycle-tracker.ts
+++ b/src/plugin/lifecycle-tracker.ts
@@ -1,47 +1,39 @@
 import type { ComponentOptions, ComponentPublicInstance } from 'vue';
-import type { VRTPluginOptions } from '../types.ts';
-import type { Collector } from '../core/collector.ts';
+import type { VRTContext } from './context.ts';
 import { measurePaint } from '../core/timer.ts';
 import { emitLog } from '../core/logger.ts';
 import { countNodes } from '../utils/dom.ts';
 
 type VueInstance = ComponentPublicInstance & { $: { uid: number } };
 
-const filterCache = new Map<string, boolean>();
-const explicitlyTracked = new Set<string>();
-
-/** Mark a component name for tracking, bypassing include/exclude filters. */
-export function markTracked(name: string): void {
-  explicitlyTracked.add(name);
-  filterCache.delete(name);
-}
-
-function shouldTrack(name: string | undefined, options: VRTPluginOptions): boolean {
+function shouldTrack(instance: VueInstance, context: VRTContext): boolean {
+  const name = getComponentName(instance);
   if (!name) return false;
-  if (explicitlyTracked.has(name)) return true;
 
-  const cached = filterCache.get(name);
+  if (context.explicitlyTracked.has(name)) return true;
+
+  const cached = context.filterCache.get(name);
   if (cached !== undefined) return cached;
 
   let result = true;
 
-  if (options.include) {
-    if (options.include instanceof RegExp) {
-      result = options.include.test(name);
+  if (context.options.include) {
+    if (context.options.include instanceof RegExp) {
+      result = context.options.include.test(name);
     } else {
-      result = options.include.includes(name);
+      result = context.options.include.includes(name);
     }
   }
 
-  if (result && options.exclude) {
-    if (options.exclude instanceof RegExp) {
-      result = !options.exclude.test(name);
+  if (result && context.options.exclude) {
+    if (context.options.exclude instanceof RegExp) {
+      result = !context.options.exclude.test(name);
     } else {
-      result = !options.exclude.includes(name);
+      result = !context.options.exclude.includes(name);
     }
   }
 
-  filterCache.set(name, result);
+  context.filterCache.set(name, result);
   return result;
 }
 
@@ -49,19 +41,16 @@ function getComponentName(instance: VueInstance): string | undefined {
   return instance.$options.name || instance.$options.__name;
 }
 
-export function createLifecycleTracker(
-  collector: Collector,
-  options: VRTPluginOptions,
-): ComponentOptions {
+export function createLifecycleTracker(context: VRTContext): ComponentOptions {
+  const { collector, options } = context;
+
   return {
     beforeMount(this: VueInstance) {
-      const name = getComponentName(this);
-      if (!shouldTrack(name, options)) return;
-      collector.trackMountStart(name!, this.$.uid);
+      if (!shouldTrack(this, context)) return;
+      collector.trackMountStart(getComponentName(this)!, this.$.uid);
     },
     mounted(this: VueInstance) {
-      const name = getComponentName(this);
-      if (!shouldTrack(name, options)) return;
+      if (!shouldTrack(this, context)) return;
       const uid = this.$.uid;
       collector.trackMountEnd(uid);
       collector.trackNodeCount(uid, countNodes(this.$el));
@@ -72,13 +61,11 @@ export function createLifecycleTracker(
       });
     },
     beforeUpdate(this: VueInstance) {
-      const name = getComponentName(this);
-      if (!shouldTrack(name, options)) return;
+      if (!shouldTrack(this, context)) return;
       collector.trackUpdateStart(this.$.uid);
     },
     updated(this: VueInstance) {
-      const name = getComponentName(this);
-      if (!shouldTrack(name, options)) return;
+      if (!shouldTrack(this, context)) return;
       const uid = this.$.uid;
       collector.trackUpdateEnd(uid);
       collector.trackNodeCount(uid, countNodes(this.$el));
@@ -91,14 +78,8 @@ export function createLifecycleTracker(
       }
     },
     unmounted(this: VueInstance) {
-      const name = getComponentName(this);
-      if (!shouldTrack(name, options)) return;
+      if (!shouldTrack(this, context)) return;
       collector.flush(this.$.uid);
     },
   };
-}
-
-export function clearFilterCache(): void {
-  filterCache.clear();
-  explicitlyTracked.clear();
 }


### PR DESCRIPTION
## Summary

- Introduce `VRTContext` interface (`src/plugin/context.ts`) with per-app `filterCache` and `explicitlyTracked` state, provided via `app.provide()`
- Replace module-level `filterCache` (Map) and `explicitlyTracked` (Set) singletons in `lifecycle-tracker.ts` — fixes multi-app state leaks
- Update `useRenderDiagnostics` to use `inject(VRT_CONTEXT_KEY)` instead of module-level `markTracked()`
- Eliminate `clearFilterCache()` export — tests no longer need manual cleanup between runs
- Align name resolution order (`name || __name`) between composable and lifecycle tracker

Closes #22

## Test plan

- [x] All 46 tests pass (no `clearFilterCache()` calls needed)
- [x] Multi-app isolation test: two apps with conflicting filters don't interfere
- [x] `useRenderDiagnostics` opt-in works via inject-based registration
- [x] `Collector` class unchanged — core layer stays pure
- [x] `pnpm build`, `pnpm lint`, `pnpm fmt:check` all clean