### PR TITLE
chore: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` running on push to main and pull requests
- Steps: fmt:check → lint → typecheck → test → build
- Uses `pnpm/action-setup@v4` with `packageManager` field from `package.json` (no explicit version needed)
- Node 24, pnpm 10 (matching project requirements)

Closes #28

## Test plan

- [x] Workflow syntax is valid YAML
- [x] `packageManager` field exists in package.json (`pnpm@10.13.1`)
- [ ] CI runs successfully on this PR (verify after push)