### PR TITLE
fix: reset RegExp lastIndex in include/exclude filters

### DIFF
--- a/src/plugin/lifecycle-tracker.ts
+++ b/src/plugin/lifecycle-tracker.ts
@@ -19,6 +19,7 @@ function shouldTrack(instance: VueInstance, context: VRTContext): boolean {
 
   if (context.options.include) {
     if (context.options.include instanceof RegExp) {
+      context.options.include.lastIndex = 0;
       result = context.options.include.test(name);
     } else {
       result = context.options.include.includes(name);
@@ -27,6 +28,7 @@ function shouldTrack(instance: VueInstance, context: VRTContext): boolean {
 
   if (result && context.options.exclude) {
     if (context.options.exclude instanceof RegExp) {
+      context.options.exclude.lastIndex = 0;
       result = !context.options.exclude.test(name);
     } else {
       result = !context.options.exclude.includes(name);


### PR DESCRIPTION
## Summary

- Reset `lastIndex = 0` before `RegExp.test()` in both `include` and `exclude` branches of `shouldTrack()`
- Prevents intermittent filtering when users pass RegExp with `g` or `y` flags

Closes #32

## Test plan

- [x] All 50 existing tests pass
- [x] `pnpm build`, `pnpm lint`, `pnpm fmt:check` all clean
- [x] Two-line fix, no behavioral change for RegExp without `g`/`y` flags