### PR TITLE
fix: track anonymous components instead of silently skipping

### DIFF
--- a/src/composables/useRenderDiagnostics.ts
+++ b/src/composables/useRenderDiagnostics.ts
@@ -1,5 +1,6 @@
 import { getCurrentInstance, inject } from 'vue';
 import { VRT_CONTEXT_KEY } from '../constants.ts';
+import { resolveComponentName } from '../utils/component-name.ts';
 
 /**
  * Opt-in a component for VRT tracking.
@@ -13,16 +14,14 @@ export function useRenderDiagnostics(): void {
   const context = inject(VRT_CONTEXT_KEY);
   if (!context) return;
 
-  const name =
-    instance.type.name || instance.type.__name || (instance.type as Record<string, unknown>).__file;
+  const name = resolveComponentName(instance);
 
-  if (!name) {
+  if (name.startsWith('Anonymous#')) {
     console.warn(
       '[VRT] useRenderDiagnostics() called on a component without a name. Add a `name` option or use <script setup> for automatic name inference.',
     );
-    return;
   }
 
-  context.explicitlyTracked.add(name as string);
-  context.filterCache.delete(name as string);
+  context.explicitlyTracked.add(name);
+  context.filterCache.delete(name);
 }

--- a/src/plugin/lifecycle-tracker.ts
+++ b/src/plugin/lifecycle-tracker.ts
@@ -4,6 +4,7 @@ import type { PaintHandle } from '../core/timer.ts';
 import { measurePaint } from '../core/timer.ts';
 import { emitLog } from '../core/logger.ts';
 import { countNodes } from '../utils/dom.ts';
+import { resolveComponentName } from '../utils/component-name.ts';
 
 type VueInstance = ComponentPublicInstance & { $: { uid: number } };
 
@@ -40,12 +41,7 @@ function shouldTrack(instance: VueInstance, context: VRTContext): boolean {
 }
 
 function getComponentName(instance: VueInstance): string {
-  return (
-    instance.$options.name ||
-    instance.$options.__name ||
-    ((instance.$options as Record<string, unknown>).__file as string) ||
-    `Anonymous#${instance.$.uid}`
-  );
+  return resolveComponentName(instance.$);
 }
 
 export function createLifecycleTracker(context: VRTContext): ComponentOptions {
@@ -65,7 +61,7 @@ export function createLifecycleTracker(context: VRTContext): ComponentOptions {
   return {
     beforeMount(this: VueInstance) {
       if (!shouldTrack(this, context)) return;
-      collector.trackMountStart(getComponentName(this)!, this.$.uid);
+      collector.trackMountStart(getComponentName(this), this.$.uid);
     },
     mounted(this: VueInstance) {
       if (!shouldTrack(this, context)) return;
@@ -95,7 +91,7 @@ export function createLifecycleTracker(context: VRTContext): ComponentOptions {
       if (!shouldTrack(this, context)) return;
       const uid = this.$.uid;
       if (collector.peek(uid)) return;
-      const name = getComponentName(this)!;
+      const name = getComponentName(this);
       collector.trackMountStart(name, uid);
       collector.trackMountEnd(uid);
       collector.trackNodeCount(uid, countNodes(this.$el));

--- a/src/utils/component-name.ts
+++ b/src/utils/component-name.ts
@@ -1,0 +1,11 @@
+import type { ComponentInternalInstance } from 'vue';
+
+export function resolveComponentName(instance: ComponentInternalInstance): string {
+  const type = instance.type as Record<string, unknown>;
+  return (
+    (type.name as string) ||
+    (type.__name as string) ||
+    (type.__file as string) ||
+    `Anonymous#${instance.uid}`
+  );
+}


### PR DESCRIPTION
## Summary

- `getComponentName` now returns a string always: falls back to `__file` (SFC path) then `Anonymous#${uid}`
- Anonymous components are tracked instead of silently ignored
- `useRenderDiagnostics()` warns via `console.warn` when called on a nameless component (explicit opt-in should have a name)
- No new options added (`warnAnonymous` option rejected as unnecessary API surface)

Closes #29

## Test plan

- [x] All 60 existing tests pass (no regressions)
- [x] `pnpm build`, `pnpm lint`, `pnpm fmt:check` all clean
- [x] Anonymous components now tracked with `Anonymous#uid` fallback name
- [x] SFC components without explicit `name` use `__file` path