### PR TITLE
perf: skip countNodes on updates unless emitting a log

### DIFF
--- a/src/plugin/lifecycle-tracker.ts
+++ b/src/plugin/lifecycle-tracker.ts
@@ -78,10 +78,10 @@ export function createLifecycleTracker(context: VRTContext): ComponentOptions {
       if (!shouldTrack(this, context)) return;
       const uid = this.$.uid;
       collector.trackUpdateEnd(uid);
-      collector.trackNodeCount(uid, countNodes(this.$el));
       if (options.updateLogInterval && options.updateLogInterval > 0) {
         const count = collector.getUpdateCount(uid);
         if (count > 0 && count % options.updateLogInterval === 0) {
+          collector.trackNodeCount(uid, countNodes(this.$el));
           const log = collector.peek(uid);
           if (log) emitLog(log, options);
         }


### PR DESCRIPTION
## Summary

- Move `countNodes(this.$el)` from every `updated` call to inside the `updateLogInterval` log emission block
- DOM traversal (`querySelectorAll('*')`) now only runs when a log will actually be emitted
- Mount still counts nodes on every mount (unchanged)
- Eliminates O(tree-size) overhead on every reactive update for tracked components

Closes #41

## Test plan

- [x] All 60 tests pass
- [x] Node count still accurate on mount logs
- [x] Node count updated at log emission intervals
- [x] `pnpm build`, `pnpm lint`, `pnpm fmt:check` all clean