### PR TITLE
feat: add log level support with severity-based console methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ app.use(VueRenderDiagnostics, {
   include: ['UserList', 'Header'], // track only these components (string[] or RegExp)
   exclude: /^Internal/, // skip matching components (string[] or RegExp)
   logToConsole: true, // default: true
+  logLevel: 'all', // 'all' | 'issues' | 'warn' | 'error' | 'silent'
   updateLogInterval: 10, // emit snapshot every 10 updates (default: disabled)
   thresholds: {
     mountTimeMs: 50, // default: 50

--- a/src/core/logger.test.ts
+++ b/src/core/logger.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { emitLog } from './logger.ts';
-import type { VRTComponentLog } from '../types.ts';
+import type { VRTComponentLog, VRTIssue } from '../types.ts';
 
 function makeLog(overrides: Partial<VRTComponentLog> = {}): VRTComponentLog {
   return {
@@ -24,31 +24,32 @@ function makeLog(overrides: Partial<VRTComponentLog> = {}): VRTComponentLog {
   };
 }
 
+function makeIssue(severity: 'info' | 'warn' | 'error'): VRTIssue {
+  return { id: 'slow-mount', severity, metric: 'mountTimeMs', value: 100, threshold: 50 };
+}
+
 describe('emitLog', () => {
-  let consoleSpy: ReturnType<typeof vi.spyOn>;
-
-  beforeEach(() => {
-    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-  });
-
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
   it('logs with [VRT] prefix and JSON by default', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const log = makeLog();
     emitLog(log, {});
 
-    expect(consoleSpy).toHaveBeenCalledOnce();
-    expect(consoleSpy).toHaveBeenCalledWith('[VRT]', JSON.stringify(log));
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy).toHaveBeenCalledWith('[VRT]', JSON.stringify(log));
   });
 
   it('does not log to console when logToConsole is false', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     emitLog(makeLog(), { logToConsole: false });
-    expect(consoleSpy).not.toHaveBeenCalled();
+    expect(spy).not.toHaveBeenCalled();
   });
 
   it('calls onLog callback with the log object', () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
     const onLog = vi.fn();
     const log = makeLog();
     emitLog(log, { onLog });
@@ -58,18 +59,99 @@ describe('emitLog', () => {
   });
 
   it('calls both console.log and onLog when both enabled', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const onLog = vi.fn();
     emitLog(makeLog(), { onLog });
 
-    expect(consoleSpy).toHaveBeenCalledOnce();
+    expect(spy).toHaveBeenCalledOnce();
     expect(onLog).toHaveBeenCalledOnce();
   });
 
   it('calls onLog even when logToConsole is false', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const onLog = vi.fn();
     emitLog(makeLog(), { logToConsole: false, onLog });
 
-    expect(consoleSpy).not.toHaveBeenCalled();
+    expect(spy).not.toHaveBeenCalled();
     expect(onLog).toHaveBeenCalledOnce();
+  });
+
+  it('uses console.warn for logs with warn-severity issues', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    emitLog(makeLog({ issues: [makeIssue('warn')] }), {});
+
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledOnce();
+  });
+
+  it('uses console.error for logs with error-severity issues', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    emitLog(makeLog({ issues: [makeIssue('error')] }), {});
+
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledOnce();
+  });
+
+  it('uses highest severity when multiple issues exist', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    emitLog(makeLog({ issues: [makeIssue('warn'), makeIssue('error')] }), {});
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledOnce();
+  });
+
+  it('logLevel issues suppresses no-issue logs', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const onLog = vi.fn();
+    emitLog(makeLog(), { logLevel: 'issues', onLog });
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(onLog).toHaveBeenCalledOnce();
+  });
+
+  it('logLevel issues shows logs with issues', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    emitLog(makeLog({ issues: [makeIssue('warn')] }), { logLevel: 'issues' });
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+  });
+
+  it('logLevel warn suppresses info-severity logs', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    emitLog(makeLog({ issues: [makeIssue('info')] }), { logLevel: 'warn' });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('logLevel warn shows warn-severity logs', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    emitLog(makeLog({ issues: [makeIssue('warn')] }), { logLevel: 'warn' });
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+  });
+
+  it('logLevel silent suppresses all console output', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onLog = vi.fn();
+    emitLog(makeLog({ issues: [makeIssue('error')] }), { logLevel: 'silent', onLog });
+
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(onLog).toHaveBeenCalledOnce();
+  });
+
+  it('onLog receives all logs regardless of logLevel', () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const onLog = vi.fn();
+    emitLog(makeLog(), { logLevel: 'silent', onLog });
+    emitLog(makeLog({ issues: [makeIssue('warn')] }), { logLevel: 'error', onLog });
+
+    expect(onLog).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,9 +1,42 @@
-import type { VRTComponentLog, VRTPluginOptions } from '../types.ts';
+import type { VRTComponentLog, VRTIssueSeverity, VRTLogLevel, VRTPluginOptions } from '../types.ts';
 import { VRT_PREFIX } from '../constants.ts';
+
+const SEVERITY_ORDER: Record<VRTIssueSeverity, number> = { info: 0, warn: 1, error: 2 };
+const LEVEL_THRESHOLD: Record<VRTLogLevel, number> = {
+  all: -1,
+  issues: 0,
+  warn: 1,
+  error: 2,
+  silent: 3,
+};
+
+function getMaxSeverity(issues: VRTComponentLog['issues']): VRTIssueSeverity | null {
+  if (issues.length === 0) return null;
+  let max: VRTIssueSeverity = issues[0].severity;
+  for (let i = 1; i < issues.length; i++) {
+    if (SEVERITY_ORDER[issues[i].severity] > SEVERITY_ORDER[max]) {
+      max = issues[i].severity;
+    }
+  }
+  return max;
+}
+
+function shouldLog(maxSeverity: VRTIssueSeverity | null, level: VRTLogLevel): boolean {
+  if (level === 'silent') return false;
+  if (level === 'all') return true;
+  if (maxSeverity === null) return false;
+  return SEVERITY_ORDER[maxSeverity] >= LEVEL_THRESHOLD[level];
+}
 
 export function emitLog(log: VRTComponentLog, options: VRTPluginOptions): void {
   if (options.logToConsole !== false) {
-    console.log(VRT_PREFIX, JSON.stringify(log));
+    const level = options.logLevel ?? 'all';
+    const maxSeverity = getMaxSeverity(log.issues);
+
+    if (shouldLog(maxSeverity, level)) {
+      const method = maxSeverity === 'error' ? 'error' : maxSeverity === 'warn' ? 'warn' : 'log';
+      console[method](VRT_PREFIX, JSON.stringify(log));
+    }
   }
   options.onLog?.(log);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export type {
   VRTIssue,
   VRTIssueId,
   VRTIssueSeverity,
+  VRTLogLevel,
   VRTMetrics,
   VRTPluginOptions,
   VRTSignals,

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,12 +46,15 @@ export interface VRTThresholds {
   updateCount: number;
 }
 
+export type VRTLogLevel = 'all' | 'issues' | 'warn' | 'error' | 'silent';
+
 export interface VRTPluginOptions {
   enabled?: boolean;
   include?: string[] | RegExp;
   exclude?: string[] | RegExp;
   thresholds?: Partial<VRTThresholds>;
   logToConsole?: boolean;
+  logLevel?: VRTLogLevel;
   updateLogInterval?: number;
   onLog?: (log: VRTComponentLog) => void;
 }


### PR DESCRIPTION
## Summary

- Add `logLevel` option to `VRTPluginOptions`: `'all'` (default) | `'issues'` | `'warn'` | `'error'` | `'silent'`
- Use `console.warn` for warn-severity issues, `console.error` for error-severity
- `logLevel: 'issues'` suppresses healthy component logs (no issues)
- `logLevel: 'silent'` suppresses all console output (equivalent to `logToConsole: false`)
- `onLog` callback always receives all logs regardless of level
- Export `VRTLogLevel` type from public API
- Update README with `logLevel` option

Closes #36

## Test plan

- [x] Default behavior unchanged (`logLevel: 'all'` = `console.log` for everything)
- [x] `console.warn` used for warn-severity issues
- [x] `console.error` used for error-severity issues
- [x] Highest severity wins when multiple issues exist
- [x] `logLevel: 'issues'` suppresses no-issue logs
- [x] `logLevel: 'warn'` suppresses info-severity logs
- [x] `logLevel: 'silent'` suppresses all console output
- [x] `onLog` receives all logs regardless of logLevel
- [x] All 81 tests pass
- [x] `pnpm build`, `pnpm lint`, `pnpm fmt:check` all clean