### PR TITLE
docs: document fragment root nodeCount limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ Returns `null` if the plugin is not installed. The `peek()` method returns a rea
 }
 ```
 
+## Known Limitations
+
+- **Fragment components report `nodeCount: 0`** — components with multiple root nodes (fragments) set `$el` to a Text/Comment node, not an Element. DOM node counting is skipped for these components. Single-root components work correctly.
+
 ## MCP Integration
 
 Logs use the `[VRT]` prefix for easy extraction by AI tools:

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,3 +1,7 @@
+/**
+ * Count descendant elements. Returns 0 for non-Element nodes
+ * (e.g., fragment-root components where $el is a Text or Comment node).
+ */
 export function countNodes(el: unknown): number {
   if (typeof Element !== 'undefined' && el instanceof Element) {
     return el.querySelectorAll('*').length;


### PR DESCRIPTION
## Summary

- Add JSDoc to `countNodes()` explaining fragment-root behavior
- Add "Known Limitations" section to README
- No code change — the current behavior (return 0 for non-Element) is correct and intentional
- Sibling-walking approach was rejected in review as it overcounts

Closes #26

## Test plan

- [x] All 81 tests pass
- [x] `pnpm build`, `pnpm lint`, `pnpm fmt:check` all clean