### PR TITLE
fix: guard duplicate timers and expose clock skew detection

### DIFF
--- a/src/core/collector.test.ts
+++ b/src/core/collector.test.ts
@@ -107,6 +107,7 @@ describe('Collector', () => {
       signals: {
         hasAsyncInSetup: false,
         dataUpdateDetected: false,
+        clockSkewDetected: false,
       },
       issues: [],
     });
@@ -240,6 +241,7 @@ describe('Collector', () => {
     const log = collector.flush(1);
     expect(log!.metrics.updateCount).toBe(0);
     expect(log!.metrics.avgUpdateMs).toBe(0);
+    expect(log!.signals.clockSkewDetected).toBe(true);
   });
 
   it('handles sub-millisecond update durations without drift', () => {

--- a/src/core/collector.ts
+++ b/src/core/collector.ts
@@ -14,6 +14,7 @@ interface ComponentTracker {
   maxUpdateMs: number;
   nodeCount: number;
   hasAsyncInSetup: boolean;
+  clockSkewDetected: boolean;
   updateTimer: TimerHandle | null;
 }
 
@@ -36,6 +37,7 @@ export class Collector {
       maxUpdateMs: 0,
       nodeCount: 0,
       hasAsyncInSetup: false,
+      clockSkewDetected: false,
       updateTimer: null,
     });
   }
@@ -45,7 +47,10 @@ export class Collector {
     if (!tracker?.mountTimer) return;
     const duration = tracker.mountTimer.stop();
     tracker.mountTimer = null;
-    if (duration < 0) return;
+    if (duration < 0) {
+      tracker.clockSkewDetected = true;
+      return;
+    }
     tracker.mountTimeMs = duration;
   }
 
@@ -58,6 +63,7 @@ export class Collector {
   trackUpdateStart(uid: number): void {
     const tracker = this.trackers.get(uid);
     if (!tracker) return;
+    if (tracker.updateTimer) tracker.updateTimer = null;
     tracker.updateTimer = startTimer();
   }
 
@@ -66,7 +72,10 @@ export class Collector {
     if (!tracker?.updateTimer) return;
     const duration = tracker.updateTimer.stop();
     tracker.updateTimer = null;
-    if (duration < 0) return;
+    if (duration < 0) {
+      tracker.clockSkewDetected = true;
+      return;
+    }
     tracker.updateCount++;
     tracker.totalUpdateMs += duration;
     if (duration > tracker.maxUpdateMs) tracker.maxUpdateMs = duration;
@@ -114,6 +123,7 @@ export class Collector {
     const signals: VRTSignals = {
       hasAsyncInSetup: tracker.hasAsyncInSetup,
       dataUpdateDetected: tracker.updateCount > 0,
+      clockSkewDetected: tracker.clockSkewDetected,
     };
 
     return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export interface VRTMetrics {
 export interface VRTSignals {
   hasAsyncInSetup: boolean;
   dataUpdateDetected: boolean;
+  clockSkewDetected: boolean;
 }
 
 export type VRTIssueSeverity = 'info' | 'warn' | 'error';


### PR DESCRIPTION
## Summary

- **#45**: `trackUpdateStart` nulls in-flight timer before creating new one
- **#46**: Add `clockSkewDetected: boolean` to `VRTSignals` — set when negative duration is rejected
- **#43**: Already closed (dom.test.ts existed from PR #51)

Closes #45, closes #46

## Test plan

- [x] Clock skew test now asserts `clockSkewDetected: true` in signals
- [x] Log structure test updated with `clockSkewDetected: false`
- [x] All 81 tests pass
- [x] `pnpm build`, `pnpm lint`, `pnpm fmt:check` all clean