### PR TITLE
chore: document $.uid and remove dead hasAsyncInSetup signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,15 +97,16 @@ Returns `null` if the plugin is not installed. The `peek()` method returns a rea
     "nodeCount": 1200
   },
   "signals": {
-    "hasAsyncInSetup": true,
-    "dataUpdateDetected": true
+    "dataUpdateDetected": true,
+    "clockSkewDetected": false
   },
   "issues": [
     {
       "id": "slow-mount",
       "severity": "warn",
       "metric": "mountTimeMs",
-      "value": 120
+      "value": 120,
+      "threshold": 50
     }
   ]
 }

--- a/src/core/collector.test.ts
+++ b/src/core/collector.test.ts
@@ -72,17 +72,6 @@ describe('Collector', () => {
     expect(log!.metrics.nodeCount).toBe(500);
   });
 
-  it('tracks async setup signal', () => {
-    const collector = new Collector();
-
-    collector.trackMountStart('AsyncComp', 1);
-    collector.trackAsyncSetup(1);
-    collector.trackMountEnd(1);
-
-    const log = collector.flush(1);
-    expect(log!.signals.hasAsyncInSetup).toBe(true);
-  });
-
   it('produces correct log structure', () => {
     const collector = new Collector();
 
@@ -105,7 +94,6 @@ describe('Collector', () => {
         nodeCount: 0,
       },
       signals: {
-        hasAsyncInSetup: false,
         dataUpdateDetected: false,
         clockSkewDetected: false,
       },
@@ -273,6 +261,5 @@ describe('Collector', () => {
     collector.trackUpdateStart(999);
     collector.trackUpdateEnd(999);
     collector.trackNodeCount(999, 100);
-    collector.trackAsyncSetup(999);
   });
 });

--- a/src/core/collector.ts
+++ b/src/core/collector.ts
@@ -13,7 +13,6 @@ interface ComponentTracker {
   totalUpdateMs: number;
   maxUpdateMs: number;
   nodeCount: number;
-  hasAsyncInSetup: boolean;
   clockSkewDetected: boolean;
   updateTimer: TimerHandle | null;
 }
@@ -36,7 +35,6 @@ export class Collector {
       totalUpdateMs: 0,
       maxUpdateMs: 0,
       nodeCount: 0,
-      hasAsyncInSetup: false,
       clockSkewDetected: false,
       updateTimer: null,
     });
@@ -87,12 +85,6 @@ export class Collector {
     tracker.nodeCount = count;
   }
 
-  trackAsyncSetup(uid: number): void {
-    const tracker = this.trackers.get(uid);
-    if (!tracker) return;
-    tracker.hasAsyncInSetup = true;
-  }
-
   getUpdateCount(uid: number): number {
     return this.trackers.get(uid)?.updateCount ?? 0;
   }
@@ -121,7 +113,6 @@ export class Collector {
     };
 
     const signals: VRTSignals = {
-      hasAsyncInSetup: tracker.hasAsyncInSetup,
       dataUpdateDetected: tracker.updateCount > 0,
       clockSkewDetected: tracker.clockSkewDetected,
     };

--- a/src/core/logger.test.ts
+++ b/src/core/logger.test.ts
@@ -16,8 +16,8 @@ function makeLog(overrides: Partial<VRTComponentLog> = {}): VRTComponentLog {
       nodeCount: 100,
     },
     signals: {
-      hasAsyncInSetup: false,
       dataUpdateDetected: false,
+      clockSkewDetected: false,
     },
     issues: [],
     ...overrides,

--- a/src/plugin/lifecycle-tracker.ts
+++ b/src/plugin/lifecycle-tracker.ts
@@ -6,6 +6,11 @@ import { emitLog } from '../core/logger.ts';
 import { countNodes } from '../utils/dom.ts';
 import { resolveComponentName } from '../utils/component-name.ts';
 
+/**
+ * $.uid is ComponentInternalInstance.uid — not part of Vue's public API
+ * but stable across all 3.x versions and used by vue-devtools/pinia.
+ * If a future Vue version removes it, replace with a WeakMap-based ID.
+ */
 type VueInstance = ComponentPublicInstance & { $: { uid: number } };
 
 function shouldTrack(instance: VueInstance, context: VRTContext): boolean {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,8 +7,12 @@ export interface VRTMetrics {
   nodeCount: number;
 }
 
+/**
+ * Async setup detection (hasAsyncInSetup) was removed because Vue 3 provides
+ * no public API to reliably detect async setup() from a global mixin.
+ * See: https://github.com/purupurupu/vue-render-diagnostics/issues/34
+ */
 export interface VRTSignals {
-  hasAsyncInSetup: boolean;
   dataUpdateDetected: boolean;
   clockSkewDetected: boolean;
 }


### PR DESCRIPTION
## Summary

- **#40**: Add JSDoc comment on `VueInstance` type explaining `$.uid` reliance and migration path
- **#34**: Remove `hasAsyncInSetup` from `VRTSignals` and `trackAsyncSetup()` from `Collector` — dead code that always returned false
- Update README log format with current signal/issue shape

Closes #40, closes #34

## Test plan

- [x] All 80 tests pass (1 removed: `tracks async setup signal`)
- [x] No references to `hasAsyncInSetup` or `trackAsyncSetup` remain
- [x] `pnpm build`, `pnpm lint`, `pnpm fmt:check` all clean