### PR TITLE
refactor: rename VRT prefix to VRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The plugin is disabled by default to prevent accidental production overhead. For
 app.use(VueRenderDiagnostics, { enabled: import.meta.env.DEV });
 ```
 
-Open your browser console — you'll see `[VRT]` prefixed JSON logs when components mount.
+Open your browser console — you'll see `[VRD]` prefixed JSON logs when components mount.
 
 ### Plugin Options
 
@@ -96,7 +96,7 @@ Returns `null` if the plugin is not installed. The `peek()` method returns a rea
 
 ```json
 {
-  "type": "vrt:component",
+  "type": "vrd:component",
   "component": "UserList",
   "timestamp": 1710000000000,
   "metrics": {
@@ -129,9 +129,9 @@ Returns `null` if the plugin is not installed. The `peek()` method returns a rea
 
 ## MCP Integration
 
-Logs use the `[VRT]` prefix for easy extraction by AI tools:
+Logs use the `[VRD]` prefix for easy extraction by AI tools:
 
-1. Extract `[VRT]` prefixed lines from console output
+1. Extract `[VRD]` prefixed lines from console output
 2. Parse as JSON
 3. Analyze with Claude / Codex
 

--- a/playground/App.vue
+++ b/playground/App.vue
@@ -3,7 +3,7 @@ import { ref } from 'vue';
 import { useRenderDiagnostics } from '../src/index.ts';
 import HeavyList from './HeavyList.vue';
 
-// Opt-in App component for VRT tracking
+// Opt-in App component for VRD tracking
 useRenderDiagnostics();
 
 const count = ref(0);
@@ -12,8 +12,8 @@ const showHeavy = ref(false);
 
 <template>
   <div>
-    <h1>VRT Playground</h1>
-    <p>Open the browser console to see [VRT] logs.</p>
+    <h1>VRD Playground</h1>
+    <p>Open the browser console to see [VRD] logs.</p>
 
     <button @click="count++">Count: {{ count }}</button>
 

--- a/playground/main.ts
+++ b/playground/main.ts
@@ -3,14 +3,5 @@ import { VueRenderDiagnostics } from '../src/index.ts';
 import App from './App.vue';
 
 const app = createApp(App);
-app.use(VueRenderDiagnostics, {
-  enabled: true,
-  updateLogInterval: 5,
-  onLog: (log) => {
-    console.table(log.metrics);
-    if (log.issues.length > 0) {
-      console.warn('Issues:', log.issues);
-    }
-  },
-});
+app.use(VueRenderDiagnostics, { enabled: true });
 app.mount('#app');

--- a/src/__tests__/plugin.test.ts
+++ b/src/__tests__/plugin.test.ts
@@ -3,7 +3,7 @@ import { mount } from '@vue/test-utils';
 import { defineComponent, ref, nextTick, KeepAlive, h } from 'vue';
 import { VueRenderDiagnostics } from '../plugin/install.ts';
 import { useRenderDiagnostics } from '../composables/useRenderDiagnostics.ts';
-import type { VRTComponentLog } from '../types.ts';
+import type { VRDComponentLog } from '../types.ts';
 import SimpleComponent from './fixtures/SimpleComponent.vue';
 
 function mountWithPlugin<T extends Record<string, unknown>>(
@@ -18,7 +18,7 @@ function mountWithPlugin<T extends Record<string, unknown>>(
   });
 }
 
-function logsFor(logs: VRTComponentLog[], name: string): VRTComponentLog[] {
+function logsFor(logs: VRDComponentLog[], name: string): VRDComponentLog[] {
   return logs.filter((l) => l.component === name);
 }
 
@@ -39,7 +39,7 @@ describe('VueRenderDiagnostics plugin', () => {
   });
 
   it('emits log after mount paint completion', async () => {
-    const logs: VRTComponentLog[] = [];
+    const logs: VRDComponentLog[] = [];
     mountWithPlugin(SimpleComponent, {
       pluginOptions: { onLog: (log) => logs.push(log) },
       props: { message: 'hello' },
@@ -54,7 +54,7 @@ describe('VueRenderDiagnostics plugin', () => {
   });
 
   it('does not track when enabled is false', async () => {
-    const logs: VRTComponentLog[] = [];
+    const logs: VRDComponentLog[] = [];
     const wrapper = mountWithPlugin(SimpleComponent, {
       pluginOptions: { enabled: false, onLog: (log) => logs.push(log) },
     });
@@ -65,7 +65,7 @@ describe('VueRenderDiagnostics plugin', () => {
   });
 
   it('respects include filter', async () => {
-    const logs: VRTComponentLog[] = [];
+    const logs: VRDComponentLog[] = [];
     mountWithPlugin(SimpleComponent, {
       pluginOptions: {
         include: ['NonExistentComponent'],
@@ -79,7 +79,7 @@ describe('VueRenderDiagnostics plugin', () => {
   });
 
   it('respects exclude filter', async () => {
-    const logs: VRTComponentLog[] = [];
+    const logs: VRDComponentLog[] = [];
     mountWithPlugin(SimpleComponent, {
       pluginOptions: {
         exclude: ['SimpleComponent'],
@@ -98,7 +98,7 @@ describe('VueRenderDiagnostics plugin', () => {
 
     await flushRaf();
 
-    expect(consoleSpy).toHaveBeenCalledWith('[VRT]', expect.any(String));
+    expect(consoleSpy).toHaveBeenCalledWith('[VRD]', expect.any(String));
   });
 
   it('does not log to console when logToConsole is false', async () => {
@@ -108,11 +108,11 @@ describe('VueRenderDiagnostics plugin', () => {
     });
 
     await flushRaf();
-    expect(consoleSpy).not.toHaveBeenCalledWith('[VRT]', expect.any(String));
+    expect(consoleSpy).not.toHaveBeenCalledWith('[VRD]', expect.any(String));
   });
 
   it('cleans up tracker on unmount without emitting extra log after paint', async () => {
-    const logs: VRTComponentLog[] = [];
+    const logs: VRDComponentLog[] = [];
     const wrapper = mountWithPlugin(SimpleComponent, {
       pluginOptions: { onLog: (log) => logs.push(log) },
     });
@@ -126,7 +126,7 @@ describe('VueRenderDiagnostics plugin', () => {
   });
 
   it('emits mount log when component unmounts before paint completes', async () => {
-    const logs: VRTComponentLog[] = [];
+    const logs: VRDComponentLog[] = [];
     const wrapper = mountWithPlugin(SimpleComponent, {
       pluginOptions: { onLog: (log) => logs.push(log) },
       props: { message: 'short-lived' },
@@ -147,7 +147,7 @@ describe('VueRenderDiagnostics plugin', () => {
   });
 
   it('emits update log at configured interval', async () => {
-    const logs: VRTComponentLog[] = [];
+    const logs: VRDComponentLog[] = [];
 
     const Counter = defineComponent({
       name: 'Counter',
@@ -166,7 +166,7 @@ describe('VueRenderDiagnostics plugin', () => {
             {
               enabled: true,
               updateLogInterval: 3,
-              onLog: (log: VRTComponentLog) => logs.push(log),
+              onLog: (log: VRDComponentLog) => logs.push(log),
             },
           ],
         ],
@@ -196,7 +196,7 @@ describe('VueRenderDiagnostics plugin', () => {
   });
 
   it('does not emit update logs when updateLogInterval is not set', async () => {
-    const logs: VRTComponentLog[] = [];
+    const logs: VRDComponentLog[] = [];
 
     const Counter = defineComponent({
       name: 'Counter2',
@@ -212,7 +212,7 @@ describe('VueRenderDiagnostics plugin', () => {
         plugins: [
           [
             VueRenderDiagnostics,
-            { enabled: true, onLog: (log: VRTComponentLog) => logs.push(log) },
+            { enabled: true, onLog: (log: VRDComponentLog) => logs.push(log) },
           ],
         ],
       },
@@ -232,7 +232,7 @@ describe('VueRenderDiagnostics plugin', () => {
   });
 
   it('respects RegExp include filter', async () => {
-    const logs: VRTComponentLog[] = [];
+    const logs: VRDComponentLog[] = [];
     mountWithPlugin(SimpleComponent, {
       pluginOptions: {
         include: /^Simple/,
@@ -245,7 +245,7 @@ describe('VueRenderDiagnostics plugin', () => {
   });
 
   it('respects RegExp exclude filter', async () => {
-    const logs: VRTComponentLog[] = [];
+    const logs: VRDComponentLog[] = [];
     mountWithPlugin(SimpleComponent, {
       pluginOptions: {
         exclude: /Simple/,
@@ -258,7 +258,7 @@ describe('VueRenderDiagnostics plugin', () => {
   });
 
   it('applies include and exclude together', async () => {
-    const logs: VRTComponentLog[] = [];
+    const logs: VRDComponentLog[] = [];
 
     const IncludedComp = defineComponent({
       name: 'IncludedComp',
@@ -279,7 +279,7 @@ describe('VueRenderDiagnostics plugin', () => {
               enabled: true,
               include: /^Included/,
               exclude: /Excluded$/,
-              onLog: (log: VRTComponentLog) => logs.push(log),
+              onLog: (log: VRDComponentLog) => logs.push(log),
             },
           ],
         ],
@@ -295,7 +295,7 @@ describe('VueRenderDiagnostics plugin', () => {
               enabled: true,
               include: /^Included/,
               exclude: /Excluded$/,
-              onLog: (log: VRTComponentLog) => logs.push(log),
+              onLog: (log: VRDComponentLog) => logs.push(log),
             },
           ],
         ],
@@ -308,8 +308,8 @@ describe('VueRenderDiagnostics plugin', () => {
   });
 
   it('tracks component that re-mounts after unmount', async () => {
-    const logs: VRTComponentLog[] = [];
-    const pluginOptions = { onLog: (log: VRTComponentLog) => logs.push(log) };
+    const logs: VRDComponentLog[] = [];
+    const pluginOptions = { onLog: (log: VRDComponentLog) => logs.push(log) };
 
     const wrapper1 = mountWithPlugin(SimpleComponent, {
       pluginOptions,
@@ -329,7 +329,7 @@ describe('VueRenderDiagnostics plugin', () => {
   });
 
   it('tracks anonymous components with fallback name', async () => {
-    const logs: VRTComponentLog[] = [];
+    const logs: VRDComponentLog[] = [];
 
     const AnonComp = defineComponent({
       template: '<div>anon</div>',
@@ -340,7 +340,7 @@ describe('VueRenderDiagnostics plugin', () => {
         plugins: [
           [
             VueRenderDiagnostics,
-            { enabled: true, onLog: (log: VRTComponentLog) => logs.push(log) },
+            { enabled: true, onLog: (log: VRDComponentLog) => logs.push(log) },
           ],
         ],
       },
@@ -352,8 +352,8 @@ describe('VueRenderDiagnostics plugin', () => {
   });
 
   it('isolates filter state between multiple app instances', async () => {
-    const logsA: VRTComponentLog[] = [];
-    const logsB: VRTComponentLog[] = [];
+    const logsA: VRDComponentLog[] = [];
+    const logsB: VRDComponentLog[] = [];
 
     // App A includes only SimpleComponent
     mountWithPlugin(SimpleComponent, {
@@ -389,7 +389,7 @@ describe('KeepAlive activated/deactivated hooks', () => {
     vi.restoreAllMocks();
   });
 
-  function createKeepAliveWrapper(logs: VRTComponentLog[]) {
+  function createKeepAliveWrapper(logs: VRDComponentLog[]) {
     const ChildA = defineComponent({
       name: 'ChildA',
       template: '<div>A</div>',
@@ -418,7 +418,7 @@ describe('KeepAlive activated/deactivated hooks', () => {
         plugins: [
           [
             VueRenderDiagnostics,
-            { enabled: true, onLog: (log: VRTComponentLog) => logs.push(log) },
+            { enabled: true, onLog: (log: VRDComponentLog) => logs.push(log) },
           ],
         ],
       },
@@ -426,7 +426,7 @@ describe('KeepAlive activated/deactivated hooks', () => {
   }
 
   it('emits log on deactivation', async () => {
-    const logs: VRTComponentLog[] = [];
+    const logs: VRDComponentLog[] = [];
     const wrapper = createKeepAliveWrapper(logs);
 
     await flushRaf();
@@ -444,7 +444,7 @@ describe('KeepAlive activated/deactivated hooks', () => {
   });
 
   it('re-initializes tracker on reactivation after flush', async () => {
-    const logs: VRTComponentLog[] = [];
+    const logs: VRDComponentLog[] = [];
     const wrapper = createKeepAliveWrapper(logs);
 
     await flushRaf();
@@ -472,7 +472,7 @@ describe('KeepAlive activated/deactivated hooks', () => {
   });
 
   it('does not overwrite tracker on first activation after mount', async () => {
-    const logs: VRTComponentLog[] = [];
+    const logs: VRDComponentLog[] = [];
     const wrapper = createKeepAliveWrapper(logs);
 
     await flushRaf();
@@ -485,7 +485,7 @@ describe('KeepAlive activated/deactivated hooks', () => {
   });
 
   it('schedules measurePaint on reactivation and emits paint log', async () => {
-    const logs: VRTComponentLog[] = [];
+    const logs: VRDComponentLog[] = [];
     const wrapper = createKeepAliveWrapper(logs);
 
     await flushRaf();
@@ -508,7 +508,7 @@ describe('KeepAlive activated/deactivated hooks', () => {
   });
 
   it('unmounted after deactivation is a no-op for the deactivated component', async () => {
-    const logs: VRTComponentLog[] = [];
+    const logs: VRDComponentLog[] = [];
     const wrapper = createKeepAliveWrapper(logs);
 
     await flushRaf();
@@ -528,7 +528,7 @@ describe('KeepAlive activated/deactivated hooks', () => {
   });
 
   it('cancels pending paint on deactivation before rAF fires', async () => {
-    const logs: VRTComponentLog[] = [];
+    const logs: VRDComponentLog[] = [];
     const wrapper = createKeepAliveWrapper(logs);
 
     // Don't flush rAF — paint is still pending
@@ -589,11 +589,11 @@ describe('useRenderDiagnostics composable', () => {
       },
     });
 
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[VRT]'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[VRD]'));
   });
 
   it('opts in a component that would be excluded by filters', async () => {
-    const logs: VRTComponentLog[] = [];
+    const logs: VRDComponentLog[] = [];
 
     const TrackedComp = defineComponent({
       name: 'TrackedComp',
@@ -611,7 +611,7 @@ describe('useRenderDiagnostics composable', () => {
             {
               enabled: true,
               include: ['SomethingElse'],
-              onLog: (log: VRTComponentLog) => logs.push(log),
+              onLog: (log: VRDComponentLog) => logs.push(log),
             },
           ],
         ],

--- a/src/composables/useRenderDiagnostics.ts
+++ b/src/composables/useRenderDiagnostics.ts
@@ -1,24 +1,24 @@
 import { getCurrentInstance, inject } from 'vue';
-import { VRT_CONTEXT_KEY } from '../constants.ts';
+import { VRD_CONTEXT_KEY } from '../constants.ts';
 import { resolveComponentName } from '../utils/component-name.ts';
 
 /**
- * Opt-in a component for VRT tracking.
- * Call in setup() to ensure this component emits [VRT] logs on mount,
+ * Opt-in a component for VRD tracking.
+ * Call in setup() to ensure this component emits [VRD] logs on mount,
  * regardless of plugin include/exclude filters.
  */
 export function useRenderDiagnostics(): void {
   const instance = getCurrentInstance();
   if (!instance) return;
 
-  const context = inject(VRT_CONTEXT_KEY);
+  const context = inject(VRD_CONTEXT_KEY);
   if (!context) return;
 
   const name = resolveComponentName(instance);
 
   if (name.startsWith('Anonymous#')) {
     console.warn(
-      '[VRT] useRenderDiagnostics() called on a component without a name. Add a `name` option or use <script setup> for automatic name inference.',
+      '[VRD] useRenderDiagnostics() called on a component without a name. Add a `name` option or use <script setup> for automatic name inference.',
     );
   }
 

--- a/src/composables/useRenderMetrics.ts
+++ b/src/composables/useRenderMetrics.ts
@@ -1,8 +1,8 @@
-import type { VRTComponentLog } from '../types.ts';
+import type { VRDComponentLog } from '../types.ts';
 import { getCurrentInstance, inject } from 'vue';
-import { VRT_CONTEXT_KEY } from '../constants.ts';
+import { VRD_CONTEXT_KEY } from '../constants.ts';
 
-export type RenderMetricsHandle = { peek: () => VRTComponentLog | null };
+export type RenderMetricsHandle = { peek: () => VRDComponentLog | null };
 
 /**
  * Read-only composable for programmatic metric retrieval.
@@ -15,7 +15,7 @@ export function useRenderMetrics(): RenderMetricsHandle | null {
   const instance = getCurrentInstance();
   if (!instance) return null;
 
-  const context = inject(VRT_CONTEXT_KEY, null);
+  const context = inject(VRD_CONTEXT_KEY, null);
   if (!context) return null;
 
   const uid = instance.uid;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,14 +1,14 @@
 import type { InjectionKey } from 'vue';
-import type { VRTThresholds } from './types.ts';
+import type { VRDThresholds } from './types.ts';
 import type { Collector } from './core/collector.ts';
-import type { VRTContext } from './plugin/context.ts';
+import type { VRDContext } from './plugin/context.ts';
 
-export const VRT_PREFIX = '[VRT]';
+export const VRD_PREFIX = '[VRD]';
 
-export const VRT_COLLECTOR_KEY: InjectionKey<Collector> = Symbol('vrt-collector');
-export const VRT_CONTEXT_KEY: InjectionKey<VRTContext> = Symbol('vrt-context');
+export const VRD_COLLECTOR_KEY: InjectionKey<Collector> = Symbol('vrd-collector');
+export const VRD_CONTEXT_KEY: InjectionKey<VRDContext> = Symbol('vrd-context');
 
-export const DEFAULT_THRESHOLDS: VRTThresholds = {
+export const DEFAULT_THRESHOLDS: VRDThresholds = {
   mountTimeMs: 100,
   updateTimeMs: 16,
   paintTimeMs: 100,

--- a/src/core/collector.ts
+++ b/src/core/collector.ts
@@ -1,4 +1,4 @@
-import type { VRTComponentLog, VRTMetrics, VRTSignals, VRTThresholds } from '../types.ts';
+import type { VRDComponentLog, VRDMetrics, VRDSignals, VRDThresholds } from '../types.ts';
 import type { TimerHandle } from './timer.ts';
 import { DEFAULT_THRESHOLDS } from '../constants.ts';
 import { detectIssues } from './detector.ts';
@@ -19,9 +19,9 @@ interface ComponentTracker {
 
 export class Collector {
   private trackers = new Map<number, ComponentTracker>();
-  private thresholds: VRTThresholds;
+  private thresholds: VRDThresholds;
 
-  constructor(thresholds?: Partial<VRTThresholds>) {
+  constructor(thresholds?: Partial<VRDThresholds>) {
     this.thresholds = { ...DEFAULT_THRESHOLDS, ...thresholds };
   }
 
@@ -89,21 +89,21 @@ export class Collector {
     return this.trackers.get(uid)?.updateCount ?? 0;
   }
 
-  peek(uid: number): VRTComponentLog | null {
+  peek(uid: number): VRDComponentLog | null {
     const tracker = this.trackers.get(uid);
     if (!tracker) return null;
     return this.buildLog(tracker);
   }
 
-  flush(uid: number): VRTComponentLog | null {
+  flush(uid: number): VRDComponentLog | null {
     const tracker = this.trackers.get(uid);
     if (!tracker) return null;
     this.trackers.delete(uid);
     return this.buildLog(tracker);
   }
 
-  private buildLog(tracker: ComponentTracker): VRTComponentLog {
-    const metrics: VRTMetrics = {
+  private buildLog(tracker: ComponentTracker): VRDComponentLog {
+    const metrics: VRDMetrics = {
       mountTimeMs: tracker.mountTimeMs ?? 0,
       paintTimeMs: tracker.paintTimeMs ?? 0,
       updateCount: tracker.updateCount,
@@ -112,7 +112,7 @@ export class Collector {
       nodeCount: tracker.nodeCount,
     };
 
-    const signals: VRTSignals = {
+    const signals: VRDSignals = {
       dataUpdateDetected: tracker.updateCount > 0,
       clockSkewDetected: tracker.clockSkewDetected,
     };

--- a/src/core/detector.test.ts
+++ b/src/core/detector.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { detectIssues } from './detector.ts';
-import type { VRTMetrics, VRTThresholds } from '../types.ts';
+import type { VRDMetrics, VRDThresholds } from '../types.ts';
 import { DEFAULT_THRESHOLDS } from '../constants.ts';
 
-function makeMetrics(overrides: Partial<VRTMetrics> = {}): VRTMetrics {
+function makeMetrics(overrides: Partial<VRDMetrics> = {}): VRDMetrics {
   return {
     mountTimeMs: 10,
     paintTimeMs: 10,
@@ -16,7 +16,7 @@ function makeMetrics(overrides: Partial<VRTMetrics> = {}): VRTMetrics {
 }
 
 describe('detectIssues', () => {
-  const thresholds: VRTThresholds = DEFAULT_THRESHOLDS;
+  const thresholds: VRDThresholds = DEFAULT_THRESHOLDS;
 
   it('returns empty array for metrics within thresholds', () => {
     const issues = detectIssues(makeMetrics(), thresholds);
@@ -101,7 +101,7 @@ describe('detectIssues', () => {
   });
 
   it('uses custom thresholds in threshold field', () => {
-    const custom: VRTThresholds = { ...DEFAULT_THRESHOLDS, mountTimeMs: 30 };
+    const custom: VRDThresholds = { ...DEFAULT_THRESHOLDS, mountTimeMs: 30 };
     const issues = detectIssues(makeMetrics({ mountTimeMs: 40 }), custom);
     expect(issues).toContainEqual(
       expect.objectContaining({ id: 'slow-mount', severity: 'warn', threshold: 30 }),

--- a/src/core/detector.ts
+++ b/src/core/detector.ts
@@ -1,17 +1,17 @@
-import type { VRTIssue, VRTIssueSeverity, VRTMetrics, VRTThresholds } from '../types.ts';
+import type { VRDIssue, VRDIssueSeverity, VRDMetrics, VRDThresholds } from '../types.ts';
 
 function classify(
   value: number,
   warnThreshold: number,
-): { severity: VRTIssueSeverity; threshold: number } {
+): { severity: VRDIssueSeverity; threshold: number } {
   const errorThreshold = warnThreshold * 2;
   return value > errorThreshold
     ? { severity: 'error', threshold: errorThreshold }
     : { severity: 'warn', threshold: warnThreshold };
 }
 
-export function detectIssues(metrics: VRTMetrics, thresholds: VRTThresholds): VRTIssue[] {
-  const issues: VRTIssue[] = [];
+export function detectIssues(metrics: VRDMetrics, thresholds: VRDThresholds): VRDIssue[] {
+  const issues: VRDIssue[] = [];
 
   if (metrics.mountTimeMs > thresholds.mountTimeMs) {
     const { severity, threshold } = classify(metrics.mountTimeMs, thresholds.mountTimeMs);

--- a/src/core/logger.test.ts
+++ b/src/core/logger.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { emitLog } from './logger.ts';
-import type { VRTComponentLog, VRTIssue } from '../types.ts';
+import type { VRDComponentLog, VRDIssue } from '../types.ts';
 
-function makeLog(overrides: Partial<VRTComponentLog> = {}): VRTComponentLog {
+function makeLog(overrides: Partial<VRDComponentLog> = {}): VRDComponentLog {
   return {
     type: 'vrt:component',
     component: 'TestComponent',
@@ -24,7 +24,7 @@ function makeLog(overrides: Partial<VRTComponentLog> = {}): VRTComponentLog {
   };
 }
 
-function makeIssue(severity: 'info' | 'warn' | 'error'): VRTIssue {
+function makeIssue(severity: 'info' | 'warn' | 'error'): VRDIssue {
   return { id: 'slow-mount', severity, metric: 'mountTimeMs', value: 100, threshold: 50 };
 }
 
@@ -33,13 +33,13 @@ describe('emitLog', () => {
     vi.restoreAllMocks();
   });
 
-  it('logs with [VRT] prefix and JSON by default', () => {
+  it('logs with [VRD] prefix and JSON by default', () => {
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const log = makeLog();
     emitLog(log, {});
 
     expect(spy).toHaveBeenCalledOnce();
-    expect(spy).toHaveBeenCalledWith('[VRT]', JSON.stringify(log));
+    expect(spy).toHaveBeenCalledWith('[VRD]', JSON.stringify(log));
   });
 
   it('does not log to console when logToConsole is false', () => {

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,8 +1,8 @@
-import type { VRTComponentLog, VRTIssueSeverity, VRTLogLevel, VRTPluginOptions } from '../types.ts';
-import { VRT_PREFIX } from '../constants.ts';
+import type { VRDComponentLog, VRDIssueSeverity, VRDLogLevel, VRDPluginOptions } from '../types.ts';
+import { VRD_PREFIX } from '../constants.ts';
 
-const SEVERITY_ORDER: Record<VRTIssueSeverity, number> = { info: 0, warn: 1, error: 2 };
-const LEVEL_THRESHOLD: Record<VRTLogLevel, number> = {
+const SEVERITY_ORDER: Record<VRDIssueSeverity, number> = { info: 0, warn: 1, error: 2 };
+const LEVEL_THRESHOLD: Record<VRDLogLevel, number> = {
   all: -1,
   issues: 0,
   warn: 1,
@@ -10,9 +10,9 @@ const LEVEL_THRESHOLD: Record<VRTLogLevel, number> = {
   silent: 3,
 };
 
-function getMaxSeverity(issues: VRTComponentLog['issues']): VRTIssueSeverity | null {
+function getMaxSeverity(issues: VRDComponentLog['issues']): VRDIssueSeverity | null {
   if (issues.length === 0) return null;
-  let max: VRTIssueSeverity = issues[0].severity;
+  let max: VRDIssueSeverity = issues[0].severity;
   for (let i = 1; i < issues.length; i++) {
     if (SEVERITY_ORDER[issues[i].severity] > SEVERITY_ORDER[max]) {
       max = issues[i].severity;
@@ -21,21 +21,21 @@ function getMaxSeverity(issues: VRTComponentLog['issues']): VRTIssueSeverity | n
   return max;
 }
 
-function shouldLog(maxSeverity: VRTIssueSeverity | null, level: VRTLogLevel): boolean {
+function shouldLog(maxSeverity: VRDIssueSeverity | null, level: VRDLogLevel): boolean {
   if (level === 'silent') return false;
   if (level === 'all') return true;
   if (maxSeverity === null) return false;
   return SEVERITY_ORDER[maxSeverity] >= LEVEL_THRESHOLD[level];
 }
 
-export function emitLog(log: VRTComponentLog, options: VRTPluginOptions): void {
+export function emitLog(log: VRDComponentLog, options: VRDPluginOptions): void {
   if (options.logToConsole !== false) {
     const level = options.logLevel ?? 'all';
     const maxSeverity = getMaxSeverity(log.issues);
 
     if (shouldLog(maxSeverity, level)) {
       const method = maxSeverity === 'error' ? 'error' : maxSeverity === 'warn' ? 'warn' : 'log';
-      console[method](VRT_PREFIX, JSON.stringify(log));
+      console[method](VRD_PREFIX, JSON.stringify(log));
     }
   }
   options.onLog?.(log);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,13 +3,13 @@ export { useRenderDiagnostics } from './composables/useRenderDiagnostics.ts';
 export { useRenderMetrics } from './composables/useRenderMetrics.ts';
 export type { RenderMetricsHandle } from './composables/useRenderMetrics.ts';
 export type {
-  VRTComponentLog,
-  VRTIssue,
-  VRTIssueId,
-  VRTIssueSeverity,
-  VRTLogLevel,
-  VRTMetrics,
-  VRTPluginOptions,
-  VRTSignals,
-  VRTThresholds,
+  VRDComponentLog,
+  VRDIssue,
+  VRDIssueId,
+  VRDIssueSeverity,
+  VRDLogLevel,
+  VRDMetrics,
+  VRDPluginOptions,
+  VRDSignals,
+  VRDThresholds,
 } from './types.ts';

--- a/src/plugin/context.ts
+++ b/src/plugin/context.ts
@@ -1,13 +1,13 @@
 import type { Collector } from '../core/collector.ts';
-import type { VRTPluginOptions } from '../types.ts';
+import type { VRDPluginOptions } from '../types.ts';
 
-export interface VRTContext {
+export interface VRDContext {
   readonly collector: Collector;
-  readonly options: VRTPluginOptions;
+  readonly options: VRDPluginOptions;
   readonly filterCache: Map<string, boolean>;
   readonly explicitlyTracked: Set<string>;
 }
 
-export function createVRTContext(collector: Collector, options: VRTPluginOptions): VRTContext {
+export function createVRDContext(collector: Collector, options: VRDPluginOptions): VRDContext {
   return { collector, options, filterCache: new Map(), explicitlyTracked: new Set() };
 }

--- a/src/plugin/install.ts
+++ b/src/plugin/install.ts
@@ -1,18 +1,18 @@
 import type { Plugin } from 'vue';
-import type { VRTPluginOptions } from '../types.ts';
-import { VRT_COLLECTOR_KEY, VRT_CONTEXT_KEY } from '../constants.ts';
+import type { VRDPluginOptions } from '../types.ts';
+import { VRD_COLLECTOR_KEY, VRD_CONTEXT_KEY } from '../constants.ts';
 import { Collector } from '../core/collector.ts';
-import { createVRTContext } from './context.ts';
+import { createVRDContext } from './context.ts';
 import { createLifecycleTracker } from './lifecycle-tracker.ts';
 
-export const VueRenderDiagnostics: Plugin<[VRTPluginOptions?]> = {
-  install(app, options: VRTPluginOptions = {}) {
+export const VueRenderDiagnostics: Plugin<[VRDPluginOptions?]> = {
+  install(app, options: VRDPluginOptions = {}) {
     if (options.enabled !== true) return;
 
     const collector = new Collector(options.thresholds);
-    const context = createVRTContext(collector, options);
-    app.provide(VRT_COLLECTOR_KEY, collector);
-    app.provide(VRT_CONTEXT_KEY, context);
+    const context = createVRDContext(collector, options);
+    app.provide(VRD_COLLECTOR_KEY, collector);
+    app.provide(VRD_CONTEXT_KEY, context);
     app.mixin(createLifecycleTracker(context));
   },
 };

--- a/src/plugin/lifecycle-tracker.ts
+++ b/src/plugin/lifecycle-tracker.ts
@@ -1,5 +1,5 @@
 import type { ComponentOptions, ComponentPublicInstance } from 'vue';
-import type { VRTContext } from './context.ts';
+import type { VRDContext } from './context.ts';
 import type { PaintHandle } from '../core/timer.ts';
 import { measurePaint } from '../core/timer.ts';
 import { emitLog } from '../core/logger.ts';
@@ -13,7 +13,7 @@ import { resolveComponentName } from '../utils/component-name.ts';
  */
 type VueInstance = ComponentPublicInstance & { $: { uid: number } };
 
-function shouldTrack(instance: VueInstance, context: VRTContext): boolean {
+function shouldTrack(instance: VueInstance, context: VRDContext): boolean {
   const name = getComponentName(instance);
 
   if (context.explicitlyTracked.has(name)) return true;
@@ -51,7 +51,7 @@ function getComponentName(instance: VueInstance): string {
   return resolveComponentName(instance.$);
 }
 
-export function createLifecycleTracker(context: VRTContext): ComponentOptions {
+export function createLifecycleTracker(context: VRDContext): ComponentOptions {
   const { collector, options } = context;
   const pendingPaints = new Map<number, PaintHandle>();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export interface VRTMetrics {
+export interface VRDMetrics {
   mountTimeMs: number;
   paintTimeMs: number;
   updateCount: number;
@@ -12,14 +12,14 @@ export interface VRTMetrics {
  * no public API to reliably detect async setup() from a global mixin.
  * See: https://github.com/purupurupu/vue-render-diagnostics/issues/34
  */
-export interface VRTSignals {
+export interface VRDSignals {
   dataUpdateDetected: boolean;
   clockSkewDetected: boolean;
 }
 
-export type VRTIssueSeverity = 'info' | 'warn' | 'error';
+export type VRDIssueSeverity = 'info' | 'warn' | 'error';
 
-export type VRTIssueId =
+export type VRDIssueId =
   | 'slow-mount'
   | 'slow-update-avg'
   | 'slow-update-max'
@@ -27,24 +27,24 @@ export type VRTIssueId =
   | 'large-dom'
   | 'excessive-updates';
 
-export interface VRTIssue {
-  id: VRTIssueId;
-  severity: VRTIssueSeverity;
-  metric: keyof VRTMetrics;
+export interface VRDIssue {
+  id: VRDIssueId;
+  severity: VRDIssueSeverity;
+  metric: keyof VRDMetrics;
   value: number;
   threshold: number;
 }
 
-export interface VRTComponentLog {
+export interface VRDComponentLog {
   type: 'vrt:component';
   component: string;
   timestamp: number;
-  metrics: VRTMetrics;
-  signals: VRTSignals;
-  issues: VRTIssue[];
+  metrics: VRDMetrics;
+  signals: VRDSignals;
+  issues: VRDIssue[];
 }
 
-export interface VRTThresholds {
+export interface VRDThresholds {
   mountTimeMs: number;
   updateTimeMs: number;
   paintTimeMs: number;
@@ -52,18 +52,18 @@ export interface VRTThresholds {
   updateCount: number;
 }
 
-export type VRTLogLevel = 'all' | 'issues' | 'warn' | 'error' | 'silent';
+export type VRDLogLevel = 'all' | 'issues' | 'warn' | 'error' | 'silent';
 
-export interface VRTPluginOptions {
+export interface VRDPluginOptions {
   /** Must be `true` to activate the plugin. Defaults to `false` to prevent accidental production overhead. */
   enabled?: boolean;
   include?: string[] | RegExp;
   exclude?: string[] | RegExp;
-  thresholds?: Partial<VRTThresholds>;
+  thresholds?: Partial<VRDThresholds>;
   logToConsole?: boolean;
   /** Controls console output filtering. Does NOT affect `onLog` — the callback always receives all logs. */
-  logLevel?: VRTLogLevel;
+  logLevel?: VRDLogLevel;
   updateLogInterval?: number;
   /** Called for every log regardless of `logLevel`. Use `logLevel` to control console output only. */
-  onLog?: (log: VRTComponentLog) => void;
+  onLog?: (log: VRDComponentLog) => void;
 }


### PR DESCRIPTION
## Summary

Rename all `VRT` references to `VRD` (Vue Render Diagnostics) before v0.1.0 publish.

- Types: `VRTMetrics` → `VRDMetrics`, etc.
- Log prefix: `[VRT]` → `[VRD]`
- Log type: `vrt:component` → `vrd:component`
- Injection keys: `vrt-collector` → `vrd-collector`
- All tests, README, playground updated

## Test plan

- [x] All 80 tests pass
- [x] `pnpm build`, `pnpm lint`, `pnpm fmt:check` all clean
- [x] No remaining `VRT` references (except historical comment about hasAsyncInSetup removal)